### PR TITLE
Ensure client_id and secret are not nil in first default_call

### DIFF
--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -836,13 +836,14 @@ module Keycloak
     protected
 
       def self.default_call(proc, client_id = '', secret = '')
-        client_id = Keycloak::Client.client_id if client_id.blank?
-        secret = Keycloak::Client.secret if secret.blank?
         begin
           tk = nil
           resp = nil
 
           Keycloak::Client.get_installation
+
+          client_id = Keycloak::Client.client_id if client_id.blank?
+          secret = Keycloak::Client.secret if secret.blank?
 
           payload = { 'client_id' => client_id,
                       'client_secret' => secret,


### PR DESCRIPTION
This makes sure that `Keycloak::Client.get_installation` is called in `default_call` before using values it sets on client. Currently, each time an app using it is restarted, and makes the first `default_call`, `client_id` and `secret` won't be set, and the request will fail. All subsequent request will work, making it hard to track. 