### PR TITLE
add client_session_state param to payload in code auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 keycloak-*.gem
 .rspec_status
+
+.idea

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -53,12 +53,12 @@ module Keycloak
                   'client_secret' => secret,
                   'username' => user,
                   'password' => password,
-                  'grant_type' => 'password' }
+                  'grant_type' => 'password'}
 
       mount_request_token(payload)
     end
 
-    def self.get_token_by_code(code, redirect_uri, client_id = '', secret = '')
+    def self.get_token_by_code(code, redirect_uri, client_id = '', secret = '', client_session_state = '')
       verify_setup
 
       client_id = @client_id if isempty?(client_id)
@@ -68,7 +68,8 @@ module Keycloak
                   'client_secret' => secret,
                   'code' => code,
                   'grant_type' => 'authorization_code',
-                  'redirect_uri' => redirect_uri }
+                  'redirect_uri' => redirect_uri,
+                  'client_session_state' => client_session_state}
 
       mount_request_token(payload)
     end
@@ -80,7 +81,13 @@ module Keycloak
       secret = @secret if isempty?(secret)
       token_endpoint = @configuration['token_endpoint'] if isempty?(token_endpoint)
 
-      payload = { 'client_id' => client_id, 'client_secret' => secret, 'audience' => client_id, 'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange', 'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token', 'subject_issuer' => issuer, 'subject_token' => issuer_token }
+      payload = { 'client_id' => client_id,
+                  'client_secret' => secret,
+                  'audience' => client_id,
+                  'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
+                  'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
+                  'subject_issuer' => issuer,
+                  'subject_token' => issuer_token}
       header = { 'Content-Type' => 'application/x-www-form-urlencoded' }
       _request = -> do
         RestClient.post(token_endpoint, payload, header){|response, request, result|

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -58,7 +58,7 @@ module Keycloak
       mount_request_token(payload)
     end
 
-    def self.get_token_by_code(code, redirect_uri, client_id = '', secret = '', client_session_state = '')
+    def self.get_token_by_code(code, redirect_uri, client_id = '', secret = '', client_session_state = '', client_session_host = '')
       verify_setup
 
       client_id = @client_id if isempty?(client_id)
@@ -69,7 +69,8 @@ module Keycloak
                   'code' => code,
                   'grant_type' => 'authorization_code',
                   'redirect_uri' => redirect_uri,
-                  'client_session_state' => client_session_state}
+                  'client_session_state' => client_session_state,
+                  'client_session_host' => client_session_host}
 
       mount_request_token(payload)
     end


### PR DESCRIPTION
When using SSO, sending `client_session_state` param (value is usually the session ID) during code token exchange registers the application with the server, so that it can send the back channel logout POST request and other session invalidation events to the `k_logout` application endpoint. Otherwise, the Keycloak server will never send the POST request to the application and the application session can remain logged in when the Keycloak session has been logged out on the server.