### PR TITLE
Add resource and secret to keycloak.rb

### DIFF
--- a/lib/generators/keycloak.rb
+++ b/lib/generators/keycloak.rb
@@ -10,3 +10,7 @@ Keycloak.realm = ''
 Keycloak.auth_server_url = ''
 # The introspect of the token will be executed every time the Keycloak::Client.has_role? method is invoked, if this setting is set to true.
 Keycloak.validate_token_when_call_has_role = false
+# secret (only if the installation file is not present)
+Keycloak.secret = ''
+# resource (client_id, only if the installation file is not present)
+Keycloak.resource = ''

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'keycloak/version'
 require 'rest-client'
 require 'json'
@@ -16,7 +18,8 @@ module Keycloak
   class << self
     attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
                   :proc_cookie_token, :proc_external_attributes,
-                  :realm, :auth_server_url, :validate_token_when_call_has_role
+                  :realm, :auth_server_url, :validate_token_when_call_has_role,
+                  :secret, :resource
   end
 
   def self.explode_exception
@@ -345,6 +348,8 @@ module Keycloak
 
           @realm = Keycloak.realm
           @auth_server_url = Keycloak.auth_server_url
+          @client_id = Keycloak.resource
+          @secret = Keycloak.secret
         end
         openid_configuration
       end

--- a/spec/keycloak_spec.rb
+++ b/spec/keycloak_spec.rb
@@ -1,7 +1,9 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Keycloak do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Keycloak::VERSION).not_to be nil
   end
 


### PR DESCRIPTION
The different environment has different settings including secret and client_id,
previously those settings in a JSON file which can't be accepted by environmental variable.
