### PR TITLE
Change attribute name

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,24 @@ It is recommended that your application has a controller that centralizes the se
 
 
 ```ruby
-Keycloak.proc_cookie_token
+Keycloak.proc_token
 ```
 
-This attribute is an anonymous method (lambda). The same must be implemented in the application so that the gem has access to the authentication token which, in turn, must be stored in the cookie. When performing the keycloak authentication through gem, the system must store the token returned in the browser cookie, such as:
+This attribute is an anonymous method (lambda). The same must be implemented in the application so that the gem has access to the authentication token which, in turn, must be stored in the cookie or session. When performing the keycloak authentication through gem, the system must store the token returned in the browser cookie, such as:
 ```ruby
 cookies.permanent[:keycloak_token] = Keycloak::Client.get_token(params[:user_login], params[:user_password])
 ```
 
-The application can retrieve the token in the cookie by implementing the `Keycloak.proc_cookie_token` method as follows:
+The application can retrieve the token in the cookie or session by implementing the `Keycloak.proc_token` method as follows:
 ```ruby
-Keycloak.proc_cookie_token = -> do
+Keycloak.proc_token = -> do
   cookies.permanent[:keycloak_token]
+end
+```
+Or
+```ruby
+Keycloak.proc_token = -> do
+  session[:keycloak_token]
 end
 ```
 This way, every time gem needs to use the token information to consume a Keycloak service, it will invoke this lambda method.

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -17,7 +17,7 @@ module Keycloak
 
   class << self
     attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
-                  :proc_cookie_token, :proc_external_attributes,
+                  :proc_token, :proc_external_attributes,
                   :realm, :auth_server_url, :validate_token_when_call_has_role,
                   :secret, :resource
   end
@@ -306,10 +306,10 @@ module Keycloak
     end
 
     def self.token
-      if !Keycloak.proc_cookie_token.nil?
-        JSON Keycloak.proc_cookie_token.call
+      if !Keycloak.proc_token.nil?
+        JSON Keycloak.proc_token.call
       else
-        raise Keycloak::ProcCookieTokenNotDefined
+        raise Keycloak::ProcTokenNotDefined
       end
     end
 


### PR DESCRIPTION
Hi @g-portugues 
I am thinking about this name for a quite long time, 
proc_cookie_token is not that general as it looks. We use it to get the token, but we are not limited to use cookie or session, we could accept any of them.

Let me know if it makes sense or not, very appreciated.
