### PR TITLE
Thread safety

### DIFF
--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -22,12 +22,6 @@ module Keycloak
 
   module Base
 
-    class << self
-      attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
-                    :realm, :auth_server_url, :validate_token_when_call_has_role,
-                    :secret, :resource
-    end
-
     def config
       Thread.current[:keycloak_config] ||= Keycloak::Config.new
     end
@@ -51,6 +45,12 @@ module Keycloak
   end
   
   extend Base
+
+  class << self
+    attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
+                  :realm, :auth_server_url, :validate_token_when_call_has_role,
+                  :secret, :resource
+  end
 
   def self.explode_exception
     Keycloak.generate_request_exception = true if Keycloak.generate_request_exception.nil?

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -15,19 +15,33 @@ module Keycloak
   OLD_KEYCLOAK_JSON_FILE = 'keycloak.json'.freeze
   KEYCLOAK_JSON_FILE = 'config/keycloak.json'.freeze
 
-  class << self
+  class Config
     attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
                   :proc_cookie_token, :proc_external_attributes,
                   :realm, :auth_server_url, :validate_token_when_call_has_role,
                   :secret, :resource
+  end
 
-    def proc_cookie_token=(proc)
-      Thread.current[:proc_cookie_token] = proc
+  module Base
+
+    def config
+      Thread.current[:keycloak_config] ||= Keycloak::Config.new
     end
 
-    def proc_cookie_token
-      Thread.current[:proc_cookie_token]
-    end
+    %w(proxy generate_request_exception keycloak_controller proc_cookie_token 
+      proc_external_attributes realm auth_server_url validate_token_when_call_has_role
+      secret resource).each do |method|
+    
+      module_eval <<-- DELEGATORS, __FILE__, ___LINE___ + 1
+        def #{method}
+          config.#{method}
+        end
+        
+        def #{method}=(value)
+          config.#{method} = (value)
+        end
+      DELEGATORS
+    end 
 
   end
 

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -32,7 +32,7 @@ module Keycloak
       proc_external_attributes realm auth_server_url validate_token_when_call_has_role
       secret resource).each do |method|
     
-      module_eval <<-- DELEGATORS, __FILE__, ___LINE___ + 1
+      module_eval <<-DELEGATORS, __FILE__, ___LINE___ + 1
         def #{method}
           config.#{method}
         end

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -63,6 +63,8 @@ module Keycloak
     @installation_file = file || KEYCLOAK_JSON_FILE
   end
 
+  extend Base
+
   module Client
     class << self
       attr_accessor :realm, :auth_server_url

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -44,6 +44,8 @@ module Keycloak
     end 
 
   end
+  
+  extend Base
 
   def self.explode_exception
     Keycloak.generate_request_exception = true if Keycloak.generate_request_exception.nil?
@@ -62,8 +64,6 @@ module Keycloak
     raise InstallationFileNotFound unless file.instance_of?(String) && File.exist?(file)
     @installation_file = file || KEYCLOAK_JSON_FILE
   end
-
-  extend Base
 
   module Client
     class << self
@@ -1054,6 +1054,7 @@ module Keycloak
         end
       end
     end
+
 end
 
 require 'keycloak/exceptions'

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -16,32 +16,37 @@ module Keycloak
   KEYCLOAK_JSON_FILE = 'config/keycloak.json'.freeze
 
   class Config
-    attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
-                  :proc_cookie_token, :proc_external_attributes,
-                  :realm, :auth_server_url, :validate_token_when_call_has_role,
-                  :secret, :resource
+    attr_accessor :proc_cookie_token, 
+                  :proc_external_attributes
   end
 
   module Base
+
+    class << self
+      attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
+                    :realm, :auth_server_url, :validate_token_when_call_has_role,
+                    :secret, :resource
+    end
 
     def config
       Thread.current[:keycloak_config] ||= Keycloak::Config.new
     end
 
-    %w(proxy generate_request_exception keycloak_controller proc_cookie_token 
-      proc_external_attributes realm auth_server_url validate_token_when_call_has_role
-      secret resource).each do |method|
-    
-      module_eval <<-DELEGATORS, __FILE__, __LINE__ + 1
-        def #{method}
-          config.#{method}
-        end
-        
-        def #{method}=(value)
-          config.#{method} = (value)
-        end
-      DELEGATORS
-    end 
+    def proc_cookie_token
+      config.proc_cookie_token
+    end
+
+    def proc_cookie_token=(value)
+      config.proc_cookie_token = value
+    end
+
+    def proc_external_attributes
+      config.proc_external_attributes
+    end
+
+    def proc_external_attributes=(value)
+      config.proc_external_attributes = value
+    end
 
   end
   

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -20,6 +20,15 @@ module Keycloak
                   :proc_cookie_token, :proc_external_attributes,
                   :realm, :auth_server_url, :validate_token_when_call_has_role,
                   :secret, :resource
+
+    def proc_cookie_token=(proc)
+      Thread.current[:proc_cookie_token] = proc
+    end
+
+    def proc_cookie_token
+      Thread.current[:proc_cookie_token]
+    end
+
   end
 
   def self.explode_exception

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -32,7 +32,7 @@ module Keycloak
       proc_external_attributes realm auth_server_url validate_token_when_call_has_role
       secret resource).each do |method|
     
-      module_eval <<-DELEGATORS, __FILE__, ___LINE___ + 1
+      module_eval <<-DELEGATORS, __FILE__, __LINE__ + 1
         def #{method}
           config.#{method}
         end


### PR DESCRIPTION
Regarding the ticket I wrote concerning thread safety when setting proc_token_cookie lambada I created a PR solving the issue. The solution is based on how the ruby-i18n gem is solving the issue since the use case is more or less the same. A locale gets set on each request as the proc_token_cookie.  Basically I added a Config class holding all the attribute accessors (hold by class << self). Keycloak extends a Base module that dynamically generates accessor functions forwarding and fetching values to the Config class. The Config class it self is initialized and written to the the thread variables. For each thread a new Config is initialized and hence we avoid having unwanted overrides and issues with running the gem within a multi threaded environment.