### PR TITLE
Fix Minor Spelling mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Its development was based on version 3.2 of Keycloak, whose documentation can be
 
 Publication of gem: https://rubygems.org/gems/keycloak
 
-Exemple: https://github.com/imagov/example-gem-keycloak
+Example: https://github.com/imagov/example-gem-keycloak
 
 ## Installation
 


### PR DESCRIPTION
`Exemple` => `Example`