### PR TITLE
Relax gemspecs for improved compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    keycloak (3.0.0)
-      json (= 2.3.0)
-      jwt (= 2.2.1)
-      rest-client (= 2.1.0)
+    keycloak (3.2.1)
+      json (>= 2.3, < 3.0)
+      jwt (>= 2.2, < 3.0)
+      rest-client (>= 2.1, < 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -13,13 +13,13 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     http-accept (1.7.0)
-    http-cookie (1.0.3)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
     json (2.3.0)
     jwt (2.2.1)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2022.0105)
     netrc (0.11.0)
     rake (13.0.1)
     rest-client (2.1.0)
@@ -42,7 +42,7 @@ GEM
     rspec-support (3.7.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.8)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,3 @@ DEPENDENCIES
   keycloak!
   rake (~> 13.0)
   rspec (~> 3.0)
-
-BUNDLED WITH
-   1.16.2

--- a/keycloak.gemspec
+++ b/keycloak.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_runtime_dependency "rest-client", "2.1.0"
-  spec.add_runtime_dependency "jwt", "2.2.1"
-  spec.add_runtime_dependency "json", "2.3.0"
+
+  spec.add_runtime_dependency "rest-client", ">= 2.1", "< 3.0"
+  spec.add_runtime_dependency "jwt",         ">= 2.2", "< 3.0"
+  spec.add_runtime_dependency "json",        ">= 2.3", "< 3.0"
 end


### PR DESCRIPTION
Hi there,

We've run into a problem whereby we are unable to use this gem in recent projects, as its runtime dependencies are locked to a specific patch version.

Most gems allow a minimum version, up to a theoretical maximum within their current major version, which I've done here.

All tests seem to still be passing.

I hope you find this PR valuable, and merge it in so that more people can use this gem.

Thanks :)