### PR TITLE
merge thread-safety / introspection_endpoint changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ Keycloak gem was developed to integrate applications and services into [Red Hat]
 
 Its development was based on version 3.2 of Keycloak, whose documentation can be found [here](http://www.keycloak.org/archive/documentation-3.2.html).
 
+Please be advised, this gem has almost no test-coverage.
+
 Publication of gem: https://rubygems.org/gems/keycloak
 
-Exemple: https://github.com/imagov/example-gem-keycloak
+Example: https://github.com/imagov/example-gem-keycloak
+
 
 ## Installation
 
@@ -180,7 +183,7 @@ When the user is already logged in and your application internally tracks the to
 
 
 ```ruby
-Keycloak::Client.get_token_introspection(token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+Keycloak::Client.get_token_introspection(token = '', client_id = '', secret = '', introspection_endpoint = '')
 ```
 
 This method returns the information from the `token` session passed as parameter. Among the information returned, the most important is the `active` field, since it informs whether the token session passed in the parameter is active or not. This will help your application control whether the logged-in user session has expired or not. If no token is passed as a parameter, gem will use the last `access_token` stored in the application's cookie.
@@ -215,14 +218,14 @@ Returns the <b>url</b> for access to the realm user registry of the installation
 
 
 ```ruby
-Keycloak::Client.has_role?(user_role, access_token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+Keycloak::Client.has_role?(user_role, access_token = '', client_id = '', secret = '', introspection_endpoint = '')
 ```
 
 The `has_role?` method decodes the JWT `access_token` and verifies that the user who owns the token has the <b>role</b> informed in the `user_role` parameter. If `access_token` is not informed then gem will use the `access_token` of the cookie.
 
 
 ```ruby
-Keycloak::Client.user_signed_in?(access_token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+Keycloak::Client.user_signed_in?(access_token = '', client_id = '', secret = '', introspection_endpoint = '')
 ```
 
 This method checks whether the `access_token` passed in the parameter is still active. To check whether the user is active or not, the gem invokes the `get_token_introspection` method internally. If `access_token` is not informed then gem will use the `access_token` of the cookie.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -173,7 +173,7 @@ Quando o usuário já estiver logado e a sua aplicação acompanhar internamente
 
 
 ```ruby
-Keycloak::Client.get_token_introspection(token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+Keycloak::Client.get_token_introspection(token = '', client_id = '', secret = '', introspection_endpoint = '')
 ```
 
 Esse método retorna a as informações da sessão do `token` passado como parâmetro. Entre as informações retornadas, a mais importante é o campo `active`, pois ele informa se a sessão do token passado no parâmetro é ativo ou não. Isso auxiliará a sua aplicação a controlar se a sessão do usuário logado expirou ou não. Caso nenhum token seja passado como parâmetro, a gem utilizará o último `access_token` armazenado no cookie da aplicação.
@@ -208,14 +208,14 @@ Retorna a <b>url</b> para acesso ao cadastro de usuários do Reino do arquivo de
 
 
 ```ruby
-Keycloak::Client.has_role?(user_role, access_token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+Keycloak::Client.has_role?(user_role, access_token = '', client_id = '', secret = '', introspection_endpoint = '')
 ```
 
 O método `has_role?` decodifica o JWT `access_token` e verifica se o usuário dono do token possui o <b>role</b> informado no parâmetro `user_role`. Caso o `access_token` não seja informado, então a gem utilizará o `access_token` do cookie.
 
 
 ```ruby
-Keycloak::Client.user_signed_in?(access_token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+Keycloak::Client.user_signed_in?(access_token = '', client_id = '', secret = '', introspection_endpoint = '')
 ```
 
 Esse método verifica se o `access_token` passado no parâmetro ainda está ativo. Para verificar se o usuário está ativo ou não, internamente a gem invoca o método `get_token_introspection`. Caso o `access_token` não seja informado, então a gem utilizará o `access_token` do cookie.

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -180,13 +180,13 @@ module Keycloak
       mount_request_token(payload)
     end
 
-    def self.get_token_introspection(token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+    def self.get_token_introspection(token = '', client_id = '', secret = '', introspection_endpoint = '')
       verify_setup
 
       client_id = @client_id if isempty?(client_id)
       secret = @secret if isempty?(secret)
       token = self.token['access_token'] if isempty?(token)
-      token_introspection_endpoint = @configuration['token_introspection_endpoint'] if isempty?(token_introspection_endpoint)
+      introspection_endpoint = @configuration['introspection_endpoint'] if isempty?(introspection_endpoint)
 
       payload = { 'token' => token }
 
@@ -197,7 +197,7 @@ module Keycloak
                  'authorization' => authorization }
 
       _request = -> do
-        RestClient.post(token_introspection_endpoint, payload, header){|response, request, result|
+        RestClient.post(introspection_endpoint, payload, header){|response, request, result|
           case response.code
           when 200..399
             response.body
@@ -289,14 +289,14 @@ module Keycloak
       "#{@auth_server_url}/realms/#{@realm}/account"
     end
 
-    def self.has_role?(user_role, access_token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+    def self.has_role?(user_role, access_token = '', client_id = '', secret = '', introspection_endpoint = '')
       verify_setup
 
       client_id = @client_id if isempty?(client_id)
       secret = @secret if isempty?(secret)
-      token_introspection_endpoint = @configuration['token_introspection_endpoint'] if isempty?(token_introspection_endpoint)
+      introspection_endpoint = @configuration['introspection_endpoint'] if isempty?(introspection_endpoint)
 
-      if !Keycloak.validate_token_when_call_has_role || user_signed_in?(access_token, client_id, secret, token_introspection_endpoint)
+      if !Keycloak.validate_token_when_call_has_role || user_signed_in?(access_token, client_id, secret, introspection_endpoint)
         dt = decoded_access_token(access_token)[0]
         dt = dt['resource_access'][client_id]
         unless dt.nil?
@@ -308,15 +308,15 @@ module Keycloak
       false
     end
 
-    def self.user_signed_in?(access_token = '', client_id = '', secret = '', token_introspection_endpoint = '')
+    def self.user_signed_in?(access_token = '', client_id = '', secret = '', introspection_endpoint = '')
       verify_setup
 
       client_id = @client_id if isempty?(client_id)
       secret = @secret if isempty?(secret)
-      token_introspection_endpoint = @configuration['token_introspection_endpoint'] if isempty?(token_introspection_endpoint)
+      introspection_endpoint = @configuration['introspection_endpoint'] if isempty?(introspection_endpoint)
 
       begin
-        JSON(get_token_introspection(access_token, client_id, secret, token_introspection_endpoint))['active'] === true
+        JSON(get_token_introspection(access_token, client_id, secret, introspection_endpoint))['active'] === true
       rescue => e
         if e.class < Keycloak::KeycloakException
           raise

--- a/lib/keycloak.rb
+++ b/lib/keycloak.rb
@@ -15,9 +15,37 @@ module Keycloak
   OLD_KEYCLOAK_JSON_FILE = 'keycloak.json'.freeze
   KEYCLOAK_JSON_FILE = 'config/keycloak.json'.freeze
 
+  class Config
+    attr_accessor :proc_cookie_token,
+                  :proc_external_attributes
+  end
+
+  module Base
+    def config
+      Thread.current[:keycloak_config] ||= Keycloak::Config.new
+    end
+
+    def proc_cookie_token
+      config.proc_cookie_token
+    end
+
+    def proc_cookie_token=(value)
+      config.proc_cookie_token = value
+    end
+
+    def proc_external_attributes
+      config.proc_external_attributes
+    end
+
+    def proc_external_attributes=(value)
+      config.proc_external_attributes = value
+    end
+  end
+
+  extend Base
+
   class << self
     attr_accessor :proxy, :generate_request_exception, :keycloak_controller,
-                  :proc_cookie_token, :proc_external_attributes,
                   :realm, :auth_server_url, :validate_token_when_call_has_role,
                   :secret, :resource
   end

--- a/spec/keycloak_spec.rb
+++ b/spec/keycloak_spec.rb
@@ -15,13 +15,38 @@ RSpec.describe Keycloak do
     end
     
     describe '.installation_file' do
-      it 'should return default installation file' do
-        expect(Keycloak.installation_file).to eq(Keycloak::KEYCLOAK_JSON_FILE)
+      # as the installation_file setting is memoized, we need to reset it between tests
+      # setting it back to nil is not possible via Keycloak.installation_file = nil
+      # so we have to reach in through 'instance_variable_set'
+      before { Keycloak.instance_variable_set(:"@installation_file", nil) }
+
+      context 'old vs. new' do
+        before { allow(File).to receive(:exist?).with(Keycloak::KEYCLOAK_JSON_FILE).and_return(new_file_exists) }
+
+        context 'the file at the new location exists' do
+          let(:new_file_exists) { true }
+
+          it 'should return default installation file' do
+            expect(Keycloak.installation_file).to eq(Keycloak::KEYCLOAK_JSON_FILE)
+          end
+        end
+
+        context 'the file at the new location does not exist' do
+          let(:new_file_exists) { false }
+
+          it 'should return the old default installation file' do
+            expect(Keycloak.installation_file).to eq(Keycloak::OLD_KEYCLOAK_JSON_FILE)
+          end
+        end
       end
 
-      it 'should return custom installation file location if previously set' do
-        Keycloak.installation_file = 'spec/fixtures/test_installation.json'
-        expect(Keycloak.installation_file).to eq('spec/fixtures/test_installation.json')
+      context 'when it is explicitly set' do
+        let(:expected_installation_file_location) { 'spec/fixtures/test_installation.json' }
+        before { Keycloak.installation_file = expected_installation_file_location }
+
+        it 'should return custom installation file location if previously set' do
+          expect(Keycloak.installation_file).to eq(expected_installation_file_location)
+        end
       end
     end
   end


### PR DESCRIPTION
hi there, this PR adopts the changes laid out in https://github.com/imagov/keycloak/pull/27 and changes the `token_introspection_endpoint` to `introspection_endpoint`

older keycloak installations duplicated the `introspection_endpoint` property under `token_introspection_endpoint`, so it should still run with older version of keycloak, however I did not verify this.

this pr seeks compatibility with keycloak v19.0.1

also:

- fix spec
- let people know that there is almost no test-coverage