### PR TITLE
Remove hard dependency of json=2.6.2

### DIFF
--- a/keycloak.gemspec
+++ b/keycloak.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.7"
   spec.add_runtime_dependency "rest-client", "2.1.0"
   spec.add_runtime_dependency "jwt", "2.4.1"
-  spec.add_runtime_dependency "json", "2.6.2"
+  spec.add_runtime_dependency "json", "~> 2.6.2"
 end


### PR DESCRIPTION
Current version of `keycloak` depended on `json=2.6.2` that can cause issues especially on ruby ~>3.2 which have json=2.6.3 as it's default json gem. If the user activate any gem that require "json", on ruby `3.2.2` -> json version `2.6.3` will be activated. And if this happens before `keycloak` was loaded you will get activation exception after loading `keycloak`: `Unable to activate keycloak-3.2.2, because json-2.6.3 conflicts with json (= 2.6.2) (Gem::ConflictError)`